### PR TITLE
Add SMS slash commands for OpenClaw plugin mode

### DIFF
--- a/lib/agent.mjs
+++ b/lib/agent.mjs
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import { join, dirname } from "node:path";
 import { pathToFileURL } from "node:url";
 import { run as defaultRun, createSemaphore } from "./utils.mjs";
+import { runSmsSlashCommand } from "./openclaw-command-bridge.mjs";
 import {
   OPENCLAW_AGENT_ID,
   OPENCLAW_PHONE_SESSION_ID,
@@ -29,6 +30,39 @@ async function _getCoreDeps() {
   const distPath = join(dirname(process.argv[1]), "extensionAPI.js");
   _coreDeps = await import(pathToFileURL(distPath).href);
   return _coreDeps;
+}
+
+function _trimmedEntryString(entry, key) {
+  const value = entry?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+async function _resolvePluginSessionContext({ _api, _coreDeps, mode = "sms" }) {
+  const deps = _coreDeps ?? await _getCoreDeps();
+  const cfg = _api.config;
+  const agentId = _pluginString(_api, "openclawAgentId", OPENCLAW_AGENT_ID);
+  const phoneSessionId = _pluginString(_api, "openclawSessionId", OPENCLAW_PHONE_SESSION_ID);
+  const smsMaxChars = _pluginNumber(_api, "smsMaxChars", SMS_MAX_CHARS);
+  const sessionKey = `${mode}:${phoneSessionId}`;
+  const storePath = deps.resolveStorePath(cfg.session?.store, { agentId });
+  const store = deps.loadSessionStore(storePath);
+  const existing = store[sessionKey];
+  const persisted = {
+    ...(existing ?? { sessionId: crypto.randomUUID() }),
+    updatedAt: Date.now(),
+  };
+  store[sessionKey] = persisted;
+  await deps.saveSessionStore(storePath, store);
+  return {
+    deps,
+    cfg,
+    agentId,
+    smsMaxChars,
+    sessionKey,
+    storePath,
+    store,
+    entry: persisted,
+  };
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -145,24 +179,26 @@ export async function discordLog({ text, run = defaultRun, _api }) {
 export async function openclawReply({ userText, mode = "voice", callerName = "", run = defaultRun, _api, _coreDeps }) {
   // ── Plugin path ────────────────────────────────────────────────────────
   if (_api) {
-    const deps = _coreDeps ?? await _getCoreDeps();
-    const cfg = _api.config;
-    const agentId = _pluginString(_api, "openclawAgentId", OPENCLAW_AGENT_ID);
-    const phoneSessionId = _pluginString(_api, "openclawSessionId", OPENCLAW_PHONE_SESSION_ID);
-    const smsMaxChars = _pluginNumber(_api, "smsMaxChars", SMS_MAX_CHARS);
-    // Shared session key — voice and SMS use the same history, matching standalone behaviour
-    const sessionKey = phoneSessionId;
-
-    const storePath = deps.resolveStorePath(cfg.session?.store, { agentId });
+    const {
+      deps,
+      cfg,
+      agentId,
+      smsMaxChars,
+      sessionKey,
+      entry,
+    } = await _resolvePluginSessionContext({ _api, _coreDeps, mode });
     const agentDir = deps.resolveAgentDir(cfg, agentId);
     const workspaceDir = deps.resolveAgentWorkspaceDir(cfg, agentId);
     await deps.ensureAgentWorkspace({ dir: workspaceDir });
-
-    const store = deps.loadSessionStore(storePath);
-    const entry = store[sessionKey] ?? { sessionId: crypto.randomUUID(), updatedAt: Date.now() };
-    store[sessionKey] = { ...entry, updatedAt: Date.now() };
-    await deps.saveSessionStore(storePath, store);
-    const resolvedModel = _resolvePrimaryModel(cfg, agentId);
+    const configuredModel = _resolvePrimaryModel(cfg, agentId);
+    const provider = _trimmedEntryString(entry, "providerOverride") ?? configuredModel.provider;
+    const model = _trimmedEntryString(entry, "modelOverride") ?? configuredModel.model;
+    const thinkLevel =
+      _trimmedEntryString(entry, "thinkingLevel") ??
+      (provider && model
+        ? deps.resolveThinkingDefault?.({ cfg, provider, model })
+        : undefined);
+    const verboseLevel = _trimmedEntryString(entry, "verboseLevel");
 
     const sessionFile = deps.resolveSessionFilePath(entry.sessionId, entry, { agentId });
     const timeoutMs = deps.resolveAgentTimeoutMs({ cfg });
@@ -178,9 +214,13 @@ export async function openclawReply({ userText, mode = "voice", callerName = "",
         agentDir,
         agentId,
         config:          cfg,
-        ...resolvedModel,
+        provider,
+        model,
+        authProfileId:   typeof entry.authProfileOverride === "string" ? entry.authProfileOverride : undefined,
+        authProfileIdSource: entry.authProfileOverrideSource === "user" ? "user" : undefined,
+        thinkLevel,
+        verboseLevel,
         prompt:          _buildPrompt(userText, mode, callerName, smsMaxChars),
-        verboseLevel:    "off",
         timeoutMs,
         runId:           `${mode}:${Date.now()}`,
         lane:            mode,
@@ -235,4 +275,44 @@ export async function openclawReply({ userText, mode = "voice", callerName = "",
   } finally {
     agentSem.release();
   }
+}
+
+/**
+ * Route an exact slash command into OpenClaw's real text-command pipeline.
+ * Non-command text returns handled=false so the caller can fall back to normal chat.
+ *
+ * @param {object} options
+ * @param {string} options.userText
+ * @param {string} [options.from]
+ * @param {string} [options.to]
+ * @param {object} [options._api]
+ * @param {object} [options._coreDeps]
+ * @returns {Promise<{ handled: boolean, reply?: string }>}
+ */
+export async function openclawCommandReply({
+  userText,
+  from = "",
+  to = "",
+  _api,
+  _coreDeps,
+}) {
+  if (!_api) {
+    return { handled: false };
+  }
+
+  const { sessionKey } = await _resolvePluginSessionContext({
+    _api,
+    _coreDeps,
+    mode: "sms",
+  });
+  const result = await runSmsSlashCommand({
+    text: userText,
+    sessionKey,
+    from,
+    to,
+  });
+  return {
+    handled: result.handled,
+    reply: result.text?.trim() || undefined,
+  };
 }

--- a/lib/agent.mjs
+++ b/lib/agent.mjs
@@ -310,6 +310,7 @@ export async function openclawCommandReply({
     sessionKey,
     from,
     to,
+    _api,
   });
   return {
     handled: result.handled,

--- a/lib/http-server.mjs
+++ b/lib/http-server.mjs
@@ -7,7 +7,7 @@ import { readFileSync } from "node:fs";
 import { handleIncomingSms, twimlMessage } from "./sms.mjs";
 import { createTwilioClient, validateWebhookSignature } from "./twilio.mjs";
 import { parseForm, toSayableText, readBody, createRateLimiter, createLogger } from "./utils.mjs";
-import { openclawReply, discordLog } from "./agent.mjs";
+import { openclawReply, openclawCommandReply, discordLog } from "./agent.mjs";
 import {
   createPendingTurn,
   getPendingTurn,
@@ -316,6 +316,8 @@ export async function createServer(config, api = null) {
         maxChars: SMS_MAX_CHARS,
         deps: {
           openclawReply: _openclawReply,
+          openclawCommandReply: ({ userText, from, to }) =>
+            openclawCommandReply({ userText, from, to, _api: api }),
           discordLog: _discordLog,
           twilioSendSms: twilioClient?.sendSms,
           smsFrom: TWILIO_SMS_FROM,

--- a/lib/openclaw-command-bridge.mjs
+++ b/lib/openclaw-command-bridge.mjs
@@ -1,0 +1,120 @@
+// @ts-check
+import { existsSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+let _commandDeps = null;
+
+function resolveOpenClawDistRoot() {
+  const explicit = process.env.CLAWPHONE_OPENCLAW_DIST_ROOT?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  if (process.argv[1]) {
+    return dirname(process.argv[1]);
+  }
+  return join(process.cwd(), "dist");
+}
+
+function resolveHashedModule(dir, prefix) {
+  const file = readdirSync(dir).find((entry) => entry.startsWith(prefix) && entry.endsWith(".js"));
+  if (!file) {
+    throw new Error(`Unable to locate ${prefix}*.js in ${dir}`);
+  }
+  return join(dir, file);
+}
+
+function collectReplyText(payload) {
+  if (!payload) {
+    return "";
+  }
+  if (Array.isArray(payload)) {
+    return payload
+      .map((entry) => collectReplyText(entry))
+      .filter(Boolean)
+      .join("\n\n");
+  }
+  if (typeof payload === "object" && typeof payload.text === "string") {
+    return payload.text.trim();
+  }
+  return "";
+}
+
+async function loadCommandDeps() {
+  if (_commandDeps) {
+    return _commandDeps;
+  }
+
+  const distRoot = resolveOpenClawDistRoot();
+  const pluginSdkDir = join(distRoot, "plugin-sdk");
+  if (!existsSync(pluginSdkDir)) {
+    throw new Error(`OpenClaw dist plugin-sdk directory not found: ${pluginSdkDir}`);
+  }
+
+  const replyPath = resolveHashedModule(pluginSdkDir, "reply-");
+  const commandsPath = resolveHashedModule(pluginSdkDir, "commands-registry-");
+  const replyModule = await import(pathToFileURL(replyPath).href);
+  const commandsModule = await import(pathToFileURL(commandsPath).href);
+  const getReplyFromConfig = replyModule?.t;
+  const maybeResolveTextAlias = commandsModule?.c;
+  if (typeof getReplyFromConfig !== "function") {
+    throw new Error(`OpenClaw reply module missing getReplyFromConfig export: ${replyPath}`);
+  }
+  if (typeof maybeResolveTextAlias !== "function") {
+    throw new Error(`OpenClaw commands module missing maybeResolveTextAlias export: ${commandsPath}`);
+  }
+
+  _commandDeps = { getReplyFromConfig, maybeResolveTextAlias };
+  return _commandDeps;
+}
+
+/**
+ * Run an exact OpenClaw slash command against the explicit SMS session key.
+ * Returns handled=false when the SMS body is not an exact text command.
+ *
+ * @param {object} options
+ * @param {string} options.text
+ * @param {string} options.sessionKey
+ * @param {string} [options.from]
+ * @param {string} [options.to]
+ * @returns {Promise<{ handled: boolean, text?: string }>}
+ */
+export async function runSmsSlashCommand({
+  text,
+  sessionKey,
+  from = "",
+  to = "",
+}) {
+  const trimmed = String(text ?? "").trim();
+  if (!trimmed.startsWith("/")) {
+    return { handled: false };
+  }
+
+  const { getReplyFromConfig, maybeResolveTextAlias } = await loadCommandDeps();
+  if (!maybeResolveTextAlias(trimmed)) {
+    return { handled: false };
+  }
+
+  const reply = await getReplyFromConfig(
+    {
+      Body: trimmed,
+      RawBody: trimmed,
+      CommandBody: trimmed,
+      BodyForCommands: trimmed,
+      From: from || undefined,
+      To: to || undefined,
+      SessionKey: sessionKey || undefined,
+      Provider: "sms",
+      Surface: "sms",
+      ChatType: "direct",
+      CommandSource: "text",
+      CommandAuthorized: true,
+    },
+    {},
+  );
+
+  return {
+    handled: true,
+    text: collectReplyText(reply),
+  };
+}

--- a/lib/openclaw-command-bridge.mjs
+++ b/lib/openclaw-command-bridge.mjs
@@ -1,28 +1,4 @@
 // @ts-check
-import { existsSync, readdirSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { pathToFileURL } from "node:url";
-
-let _commandDeps = null;
-
-function resolveOpenClawDistRoot() {
-  const explicit = process.env.CLAWPHONE_OPENCLAW_DIST_ROOT?.trim();
-  if (explicit) {
-    return explicit;
-  }
-  if (process.argv[1]) {
-    return dirname(process.argv[1]);
-  }
-  return join(process.cwd(), "dist");
-}
-
-function resolveHashedModule(dir, prefix) {
-  const file = readdirSync(dir).find((entry) => entry.startsWith(prefix) && entry.endsWith(".js"));
-  if (!file) {
-    throw new Error(`Unable to locate ${prefix}*.js in ${dir}`);
-  }
-  return join(dir, file);
-}
 
 function collectReplyText(payload) {
   if (!payload) {
@@ -40,34 +16,6 @@ function collectReplyText(payload) {
   return "";
 }
 
-async function loadCommandDeps() {
-  if (_commandDeps) {
-    return _commandDeps;
-  }
-
-  const distRoot = resolveOpenClawDistRoot();
-  const pluginSdkDir = join(distRoot, "plugin-sdk");
-  if (!existsSync(pluginSdkDir)) {
-    throw new Error(`OpenClaw dist plugin-sdk directory not found: ${pluginSdkDir}`);
-  }
-
-  const replyPath = resolveHashedModule(pluginSdkDir, "reply-");
-  const commandsPath = resolveHashedModule(pluginSdkDir, "commands-registry-");
-  const replyModule = await import(pathToFileURL(replyPath).href);
-  const commandsModule = await import(pathToFileURL(commandsPath).href);
-  const getReplyFromConfig = replyModule?.t;
-  const maybeResolveTextAlias = commandsModule?.c;
-  if (typeof getReplyFromConfig !== "function") {
-    throw new Error(`OpenClaw reply module missing getReplyFromConfig export: ${replyPath}`);
-  }
-  if (typeof maybeResolveTextAlias !== "function") {
-    throw new Error(`OpenClaw commands module missing maybeResolveTextAlias export: ${commandsPath}`);
-  }
-
-  _commandDeps = { getReplyFromConfig, maybeResolveTextAlias };
-  return _commandDeps;
-}
-
 /**
  * Run an exact OpenClaw slash command against the explicit SMS session key.
  * Returns handled=false when the SMS body is not an exact text command.
@@ -77,6 +25,7 @@ async function loadCommandDeps() {
  * @param {string} options.sessionKey
  * @param {string} [options.from]
  * @param {string} [options.to]
+ * @param {object} options._api
  * @returns {Promise<{ handled: boolean, text?: string }>}
  */
 export async function runSmsSlashCommand({
@@ -84,37 +33,81 @@ export async function runSmsSlashCommand({
   sessionKey,
   from = "",
   to = "",
+  _api,
 }) {
   const trimmed = String(text ?? "").trim();
   if (!trimmed.startsWith("/")) {
     return { handled: false };
   }
 
-  const { getReplyFromConfig, maybeResolveTextAlias } = await loadCommandDeps();
-  if (!maybeResolveTextAlias(trimmed)) {
+  const cfg = _api?.config ?? {};
+  const channelRuntime = _api?.runtime?.channel;
+  const isExactCommand = channelRuntime?.commands?.isControlCommandMessage;
+  const shouldHandleTextCommands = channelRuntime?.commands?.shouldHandleTextCommands;
+  const finalizeInboundContext = channelRuntime?.reply?.finalizeInboundContext;
+  const dispatchReplyWithBufferedBlockDispatcher =
+    channelRuntime?.reply?.dispatchReplyWithBufferedBlockDispatcher;
+  if (typeof isExactCommand !== "function" || typeof shouldHandleTextCommands !== "function") {
+    throw new Error("OpenClaw runtime missing command detection helpers");
+  }
+  if (
+    typeof finalizeInboundContext !== "function" ||
+    typeof dispatchReplyWithBufferedBlockDispatcher !== "function"
+  ) {
+    throw new Error("OpenClaw runtime missing reply dispatch helpers");
+  }
+
+  const canUseTextCommands = shouldHandleTextCommands({
+    cfg,
+    surface: "sms",
+    commandSource: "text",
+  });
+  if (!canUseTextCommands || !isExactCommand(trimmed, cfg)) {
     return { handled: false };
   }
 
-  const reply = await getReplyFromConfig(
-    {
-      Body: trimmed,
-      RawBody: trimmed,
-      CommandBody: trimmed,
-      BodyForCommands: trimmed,
-      From: from || undefined,
-      To: to || undefined,
-      SessionKey: sessionKey || undefined,
-      Provider: "sms",
-      Surface: "sms",
-      ChatType: "direct",
-      CommandSource: "text",
-      CommandAuthorized: true,
+  /** @type {Array<{ text?: string }>} */
+  const delivered = [];
+  /** @type {unknown | undefined} */
+  let dispatchError;
+
+  const finalized = finalizeInboundContext({
+    Body: trimmed,
+    RawBody: trimmed,
+    CommandBody: trimmed,
+    BodyForCommands: trimmed,
+    BodyForAgent: trimmed,
+    From: from || undefined,
+    To: to || undefined,
+    SessionKey: sessionKey || undefined,
+    Provider: "sms",
+    Surface: "sms",
+    ChatType: "direct",
+    CommandSource: "text",
+    CommandAuthorized: true,
+  });
+
+  await dispatchReplyWithBufferedBlockDispatcher({
+    ctx: finalized,
+    cfg,
+    dispatcherOptions: {
+      deliver: async (payload) => {
+        if (payload && typeof payload === "object") {
+          delivered.push(payload);
+        }
+      },
+      onError: (error) => {
+        dispatchError = error;
+      },
     },
-    {},
-  );
+  });
+
+  if (dispatchError) {
+    throw dispatchError;
+  }
 
   return {
     handled: true,
-    text: collectReplyText(reply),
+    text: collectReplyText(delivered),
   };
 }

--- a/lib/sms.mjs
+++ b/lib/sms.mjs
@@ -28,8 +28,15 @@ export function twimlMessage(text) {
 
 // Best-effort normalization to avoid UCS2 where possible (which increases segments),
 // and to enforce a hard max length (Twilio trial accounts can warn/fail on long bodies).
-export function normalizeSmsText(input, { maxChars = 280 } = {}) {
+/**
+ * @param {*} input
+ * @param {{ maxChars?: number }} [options]
+ */
+export function normalizeSmsText(input, { maxChars } = {}) {
   let s = String(input || "");
+  const cap = typeof maxChars === "number" && Number.isFinite(maxChars) && maxChars > 0
+    ? maxChars
+    : undefined;
 
   // Replace common Unicode punctuation with ASCII to reduce UCS2 likelihood.
   s = s
@@ -42,9 +49,9 @@ export function normalizeSmsText(input, { maxChars = 280 } = {}) {
   s = s.replace(/\s+/g, " ").trim();
 
   // Hard cap.
-  if (s.length > maxChars) {
+  if (cap !== undefined && s.length > cap) {
     const suffix = "…";
-    s = s.slice(0, Math.max(0, maxChars - suffix.length)).trimEnd() + suffix;
+    s = s.slice(0, Math.max(0, cap - suffix.length)).trimEnd() + suffix;
   }
 
   return s;
@@ -115,7 +122,7 @@ export async function handleIncomingSms({
         to,
       });
       if (exactCommandReply?.handled) {
-        const commandReply = normalizeSmsText(exactCommandReply.reply || "Okay", { maxChars });
+        const commandReply = normalizeSmsText(exactCommandReply.reply || "Okay");
         log(`[clawphone:sms] command reply (${commandReply.length} chars)`);
         return {
           twiml: twimlMessage(commandReply),

--- a/lib/sms.mjs
+++ b/lib/sms.mjs
@@ -5,6 +5,7 @@ import twilio from "twilio";
 /**
  * @typedef {object} SmsDeps
  * @property {(opts: { userText: string, mode: string }) => Promise<string>}  openclawReply
+ * @property {((opts: { userText: string, from?: string, to?: string }) => Promise<{ handled: boolean, reply?: string }> )=} openclawCommandReply
  * @property {((opts: { text: string }) => Promise<void>)=}                   discordLog
  * @property {((opts: { to: string, from: string, body: string }) => Promise<*>)=} twilioSendSms
  * @property {string=} smsFrom
@@ -104,6 +105,28 @@ export async function handleIncomingSms({
   }
 
   const smsFrom = deps.smsFrom || to;
+  const commandCandidate = String(text ?? "").trim();
+  let exactCommandReply;
+  if (commandCandidate.startsWith("/") && deps.openclawCommandReply) {
+    try {
+      exactCommandReply = await deps.openclawCommandReply({
+        userText: commandCandidate,
+        from,
+        to,
+      });
+      if (exactCommandReply?.handled) {
+        const commandReply = normalizeSmsText(exactCommandReply.reply || "Okay", { maxChars });
+        log(`[clawphone:sms] command reply (${commandReply.length} chars)`);
+        return {
+          twiml: twimlMessage(commandReply),
+          didAck: false,
+          startAsync: null,
+        };
+      }
+    } catch (e) {
+      error(`[clawphone:sms] command bridge failed: ${String(e)}`);
+    }
+  }
 
   // Try fast path
   try {

--- a/test/agent.test.mjs
+++ b/test/agent.test.mjs
@@ -8,17 +8,21 @@ import { OPENCLAW_MAX_CONCURRENT, DISCORD_LOG_CHANNEL_ID } from "../lib/config.m
 
 // ─── Helpers for plugin-path tests ───────────────────────────────────────────
 
-function makeCoreDeps(replyText = "Plugin reply") {
-  const store = {};
+function makeCoreDeps(replyText = "Plugin reply", initialStore = {}) {
+  const store = structuredClone(initialStore);
   return {
     resolveStorePath: mock.fn(() => "/tmp/test-store.json"),
     resolveAgentDir: mock.fn(() => "/tmp/test-agent"),
     resolveAgentWorkspaceDir: mock.fn(() => "/tmp/test-workspace"),
     ensureAgentWorkspace: async () => {},
-    loadSessionStore: () => ({ ...store }),
-    saveSessionStore: async (path, data) => { Object.assign(store, data); },
+    loadSessionStore: () => structuredClone(store),
+    saveSessionStore: async (path, data) => {
+      for (const key of Object.keys(store)) delete store[key];
+      Object.assign(store, structuredClone(data));
+    },
     resolveSessionFilePath: mock.fn(() => "/tmp/test-session.jsonl"),
     resolveAgentTimeoutMs: mock.fn(() => 30000),
+    resolveThinkingDefault: mock.fn(() => "low"),
     runEmbeddedPiAgent: mock.fn(async () => ({
       payloads: [{ text: replyText, isError: false }],
       meta: { sessionId: crypto.randomUUID(), provider: "anthropic", model: "claude" },
@@ -131,7 +135,7 @@ describe("openclawReply — plugin path", () => {
 
     const call = /** @type {any[]} */ (deps.runEmbeddedPiAgent.mock.calls)[0].arguments[0];
     assert.strictEqual(call.agentId, "my-agent");
-    assert.strictEqual(call.sessionKey, "my-session");
+    assert.strictEqual(call.sessionKey, "sms:my-session");
     assert.strictEqual(call.provider, "openai-codex");
     assert.strictEqual(call.model, "gpt-5.4");
     assert.ok(call.prompt.includes("<= 160 characters"), `unexpected prompt: ${call.prompt}`);
@@ -145,7 +149,7 @@ describe("openclawReply — plugin path", () => {
     );
   });
 
-  it("uses the same session key for voice and sms (shared history)", async () => {
+  it("uses distinct mode-prefixed session keys for voice and sms", async () => {
     const voiceDeps = makeCoreDeps("voice reply");
     const smsDeps = makeCoreDeps("sms reply");
     const api = makeApi();
@@ -158,9 +162,47 @@ describe("openclawReply — plugin path", () => {
     const voiceKey   = voiceCalls[0].arguments[0].sessionKey;
     const smsKey     = smsCalls[0].arguments[0].sessionKey;
 
-    assert.strictEqual(voiceKey, smsKey, "voice and SMS must share the same session key");
-    assert.ok(!voiceKey.startsWith("voice:"), `session key must not have mode prefix, got ${voiceKey}`);
-    assert.ok(!smsKey.startsWith("sms:"),     `session key must not have mode prefix, got ${smsKey}`);
+    assert.strictEqual(voiceKey, "voice:phone");
+    assert.strictEqual(smsKey, "sms:phone");
+    assert.notStrictEqual(voiceKey, smsKey, "voice and SMS should not share the same session key");
+  });
+
+  it("reuses stored provider, model, thinking, verbose, and auth overrides", async () => {
+    const deps = makeCoreDeps("Override reply", {
+      "sms:my-session": {
+        sessionId: "session-123",
+        providerOverride: "azure-openai-responses",
+        modelOverride: "gpt-5.3-codex-spark",
+        thinkingLevel: "high",
+        verboseLevel: "on",
+        authProfileOverride: "azure-openai-responses:default",
+        authProfileOverrideSource: "user",
+      },
+    });
+    const api = makeApi(
+      {
+        agents: {
+          defaults: {
+            model: { primary: "openai-codex/gpt-5.4" },
+          },
+        },
+      },
+      {
+        openclawSessionId: "my-session",
+      },
+    );
+
+    await openclawReply({ userText: "hello", mode: "sms", _api: api, _coreDeps: deps });
+
+    const call = /** @type {any[]} */ (deps.runEmbeddedPiAgent.mock.calls)[0].arguments[0];
+    assert.strictEqual(call.sessionId, "session-123");
+    assert.strictEqual(call.sessionKey, "sms:my-session");
+    assert.strictEqual(call.provider, "azure-openai-responses");
+    assert.strictEqual(call.model, "gpt-5.3-codex-spark");
+    assert.strictEqual(call.thinkLevel, "high");
+    assert.strictEqual(call.verboseLevel, "on");
+    assert.strictEqual(call.authProfileId, "azure-openai-responses:default");
+    assert.strictEqual(call.authProfileIdSource, "user");
   });
 
   it("passes correct prompt framing for voice mode to runEmbeddedPiAgent", async () => {

--- a/test/openclaw-command-bridge.test.mjs
+++ b/test/openclaw-command-bridge.test.mjs
@@ -1,0 +1,62 @@
+// @ts-check
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+test("runSmsSlashCommand handles only exact slash commands against the SMS session key", async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "clawphone-command-bridge-"));
+  const pluginSdkDir = join(tempDir, "plugin-sdk");
+  mkdirSync(pluginSdkDir, { recursive: true });
+  writeFileSync(
+    join(pluginSdkDir, "commands-registry-test.js"),
+    'export const c = (raw) => raw === "/status" ? "/status" : null;\n',
+    "utf8",
+  );
+  writeFileSync(
+    join(pluginSdkDir, "reply-test.js"),
+    [
+      "export const t = async (ctx) => ([",
+      '  { text: `handled:${ctx.Body}:${ctx.SessionKey}:${ctx.CommandSource}` },',
+      "]);",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const prevDistRoot = process.env.CLAWPHONE_OPENCLAW_DIST_ROOT;
+  process.env.CLAWPHONE_OPENCLAW_DIST_ROOT = tempDir;
+
+  try {
+    const bridgeUrl = new URL(`../lib/openclaw-command-bridge.mjs?ts=${Date.now()}`, import.meta.url);
+    const { runSmsSlashCommand } = await import(bridgeUrl.href);
+
+    const handled = await runSmsSlashCommand({
+      text: "/status",
+      sessionKey: "sms:phone",
+      from: "+15550000001",
+      to: "+15550000002",
+    });
+    assert.deepEqual(handled, {
+      handled: true,
+      text: "handled:/status:sms:phone:text",
+    });
+
+    const notACommand = await runSmsSlashCommand({
+      text: "hello there",
+      sessionKey: "sms:phone",
+    });
+    assert.deepEqual(notACommand, { handled: false });
+
+    const notExact = await runSmsSlashCommand({
+      text: "/status please",
+      sessionKey: "sms:phone",
+    });
+    assert.deepEqual(notExact, { handled: false });
+  } finally {
+    if (prevDistRoot === undefined) delete process.env.CLAWPHONE_OPENCLAW_DIST_ROOT;
+    else process.env.CLAWPHONE_OPENCLAW_DIST_ROOT = prevDistRoot;
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/openclaw-command-bridge.test.mjs
+++ b/test/openclaw-command-bridge.test.mjs
@@ -1,62 +1,56 @@
 // @ts-check
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+
+import { runSmsSlashCommand } from "../lib/openclaw-command-bridge.mjs";
 
 test("runSmsSlashCommand handles only exact slash commands against the SMS session key", async () => {
-  const tempDir = mkdtempSync(join(tmpdir(), "clawphone-command-bridge-"));
-  const pluginSdkDir = join(tempDir, "plugin-sdk");
-  mkdirSync(pluginSdkDir, { recursive: true });
-  writeFileSync(
-    join(pluginSdkDir, "commands-registry-test.js"),
-    'export const c = (raw) => raw === "/status" ? "/status" : null;\n',
-    "utf8",
-  );
-  writeFileSync(
-    join(pluginSdkDir, "reply-test.js"),
-    [
-      "export const t = async (ctx) => ([",
-      '  { text: `handled:${ctx.Body}:${ctx.SessionKey}:${ctx.CommandSource}` },',
-      "]);",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
+  const api = {
+    config: { commands: { text: true } },
+    runtime: {
+      channel: {
+        commands: {
+          isControlCommandMessage: (raw) => raw === "/status",
+          shouldHandleTextCommands: () => true,
+        },
+        reply: {
+          finalizeInboundContext: (ctx) => ({
+            ...ctx,
+            CommandAuthorized: ctx.CommandAuthorized === true,
+          }),
+          dispatchReplyWithBufferedBlockDispatcher: async ({ ctx, dispatcherOptions }) => {
+            await dispatcherOptions.deliver({
+              text: `handled:${ctx.Body}:${ctx.SessionKey}:${ctx.CommandSource}`,
+            });
+          },
+        },
+      },
+    },
+  };
 
-  const prevDistRoot = process.env.CLAWPHONE_OPENCLAW_DIST_ROOT;
-  process.env.CLAWPHONE_OPENCLAW_DIST_ROOT = tempDir;
+  const handled = await runSmsSlashCommand({
+    text: "/status",
+    sessionKey: "sms:phone",
+    from: "+15550000001",
+    to: "+15550000002",
+    _api: api,
+  });
+  assert.deepEqual(handled, {
+    handled: true,
+    text: "handled:/status:sms:phone:text",
+  });
 
-  try {
-    const bridgeUrl = new URL(`../lib/openclaw-command-bridge.mjs?ts=${Date.now()}`, import.meta.url);
-    const { runSmsSlashCommand } = await import(bridgeUrl.href);
+  const notACommand = await runSmsSlashCommand({
+    text: "hello there",
+    sessionKey: "sms:phone",
+    _api: api,
+  });
+  assert.deepEqual(notACommand, { handled: false });
 
-    const handled = await runSmsSlashCommand({
-      text: "/status",
-      sessionKey: "sms:phone",
-      from: "+15550000001",
-      to: "+15550000002",
-    });
-    assert.deepEqual(handled, {
-      handled: true,
-      text: "handled:/status:sms:phone:text",
-    });
-
-    const notACommand = await runSmsSlashCommand({
-      text: "hello there",
-      sessionKey: "sms:phone",
-    });
-    assert.deepEqual(notACommand, { handled: false });
-
-    const notExact = await runSmsSlashCommand({
-      text: "/status please",
-      sessionKey: "sms:phone",
-    });
-    assert.deepEqual(notExact, { handled: false });
-  } finally {
-    if (prevDistRoot === undefined) delete process.env.CLAWPHONE_OPENCLAW_DIST_ROOT;
-    else process.env.CLAWPHONE_OPENCLAW_DIST_ROOT = prevDistRoot;
-    rmSync(tempDir, { recursive: true, force: true });
-  }
+  const notExact = await runSmsSlashCommand({
+    text: "/status please",
+    sessionKey: "sms:phone",
+    _api: api,
+  });
+  assert.deepEqual(notExact, { handled: false });
 });

--- a/test/sms.test.mjs
+++ b/test/sms.test.mjs
@@ -57,6 +57,46 @@ test("handleIncomingSms: fast path returns full reply and no async", async () =>
   assert.equal(calls.send, 0);
 });
 
+test("handleIncomingSms: exact command replies bypass the conversational path", async () => {
+  let openclawCalled = false;
+  const res = await handleIncomingSms({
+    form: { From: "+15550000001", To: "+15550000002", Body: "/status" },
+    deps: {
+      openclawCommandReply: async ({ userText }) => ({
+        handled: true,
+        reply: `command:${userText}`,
+      }),
+      openclawReply: async () => {
+        openclawCalled = true;
+        return "chat reply";
+      },
+    },
+    fastTimeoutMs: 50,
+    log: () => {},
+  });
+
+  assert.equal(res.didAck, false);
+  assert.equal(res.startAsync, null);
+  assert.match(res.twiml, /command:\/status/);
+  assert.equal(openclawCalled, false);
+});
+
+test("handleIncomingSms: unhandled slash commands fall back to normal conversation", async () => {
+  const res = await handleIncomingSms({
+    form: { From: "+15550000001", To: "+15550000002", Body: "/not-a-command but chatty" },
+    deps: {
+      openclawCommandReply: async () => ({ handled: false }),
+      openclawReply: async () => "chat reply",
+    },
+    fastTimeoutMs: 50,
+    log: () => {},
+  });
+
+  assert.equal(res.didAck, false);
+  assert.equal(res.startAsync, null);
+  assert.match(res.twiml, /chat reply/);
+});
+
 test("handleIncomingSms: slow path acks and sends async follow-up", async () => {
   const calls = { openclaw: 0, send: 0 };
 

--- a/test/sms.test.mjs
+++ b/test/sms.test.mjs
@@ -81,6 +81,28 @@ test("handleIncomingSms: exact command replies bypass the conversational path", 
   assert.equal(openclawCalled, false);
 });
 
+test("handleIncomingSms: exact command replies are not truncated by the conversational SMS cap", async () => {
+  const commandReply = "This command reply should stay intact even when the normal SMS cap is tiny.";
+  const res = await handleIncomingSms({
+    form: { From: "+15550000001", To: "+15550000002", Body: "/status" },
+    deps: {
+      openclawCommandReply: async () => ({
+        handled: true,
+        reply: commandReply,
+      }),
+      openclawReply: async () => "chat reply",
+    },
+    maxChars: 12,
+    fastTimeoutMs: 50,
+    log: () => {},
+  });
+
+  assert.equal(res.didAck, false);
+  assert.equal(res.startAsync, null);
+  assert.match(res.twiml, new RegExp(commandReply.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.doesNotMatch(res.twiml, /…/);
+});
+
 test("handleIncomingSms: unhandled slash commands fall back to normal conversation", async () => {
   const res = await handleIncomingSms({
     form: { From: "+15550000001", To: "+15550000002", Body: "/not-a-command but chatty" },


### PR DESCRIPTION
## Summary

- route exact SMS slash commands into OpenClaw's real text-command pipeline instead of treating them as normal chat
- keep SMS and voice session keys separate while still reusing per-session model, thinking, verbose, and auth overrides
- preserve the full slash-command reply body instead of truncating it to the normal conversational SMS cap
- add focused bridge, agent, and SMS tests for the new command path

## Why

Once plugin mode is working, exact SMS slash commands like `/status`, `/new`, `/model`, and `/think` should behave like real OpenClaw commands rather than being rewritten into conversational prompts.

This keeps the behavior aligned with OpenClaw core command handling and makes it possible to manage the SMS session directly from the phone.

## Dependency note

This branch currently includes the plugin-mode bugfix from #55 as a prerequisite. The intent is to merge #55 first if desired; after that, the remaining commits here are the SMS slash-command feature work.

## Verification

- `npm test`
- `npm run lint`
- `npm run typecheck`
- manual local Twilio-signed SMS probes for `/status`, `/new`, `/model`, and `/think`
