### PR TITLE
Canonicalize plugin-mode SMS session keys

### DIFF
--- a/lib/agent.mjs
+++ b/lib/agent.mjs
@@ -1,8 +1,8 @@
 // @ts-check
-import crypto from "node:crypto";
 import { join, dirname } from "node:path";
 import { pathToFileURL } from "node:url";
 import { run as defaultRun, createSemaphore } from "./utils.mjs";
+import { resolvePluginSessionEntry } from "./plugin-session-key.mjs";
 import {
   OPENCLAW_AGENT_ID,
   OPENCLAW_PHONE_SESSION_ID,
@@ -150,8 +150,6 @@ export async function openclawReply({ userText, mode = "voice", callerName = "",
     const agentId = _pluginString(_api, "openclawAgentId", OPENCLAW_AGENT_ID);
     const phoneSessionId = _pluginString(_api, "openclawSessionId", OPENCLAW_PHONE_SESSION_ID);
     const smsMaxChars = _pluginNumber(_api, "smsMaxChars", SMS_MAX_CHARS);
-    // Shared session key — voice and SMS use the same history, matching standalone behaviour
-    const sessionKey = phoneSessionId;
 
     const storePath = deps.resolveStorePath(cfg.session?.store, { agentId });
     const agentDir = deps.resolveAgentDir(cfg, agentId);
@@ -159,7 +157,11 @@ export async function openclawReply({ userText, mode = "voice", callerName = "",
     await deps.ensureAgentWorkspace({ dir: workspaceDir });
 
     const store = deps.loadSessionStore(storePath);
-    const entry = store[sessionKey] ?? { sessionId: crypto.randomUUID(), updatedAt: Date.now() };
+    const { key: sessionKey, entry } = resolvePluginSessionEntry({
+      store,
+      agentId,
+      sessionKey: phoneSessionId,
+    });
     store[sessionKey] = { ...entry, updatedAt: Date.now() };
     await deps.saveSessionStore(storePath, store);
     const resolvedModel = _resolvePrimaryModel(cfg, agentId);

--- a/lib/plugin-session-key.mjs
+++ b/lib/plugin-session-key.mjs
@@ -1,0 +1,63 @@
+// @ts-check
+import crypto from "node:crypto";
+
+function normalizeAgentId(agentId) {
+  return typeof agentId === "string" && agentId.trim()
+    ? agentId.trim().toLowerCase()
+    : "main";
+}
+
+function entryUpdatedAt(entry) {
+  return typeof entry?.updatedAt === "number" && Number.isFinite(entry.updatedAt) ? entry.updatedAt : 0;
+}
+
+function mergeSessionEntries(primary, secondary) {
+  if (primary && secondary) {
+    const merged = {
+      ...secondary,
+      ...primary,
+      updatedAt: Math.max(entryUpdatedAt(primary), entryUpdatedAt(secondary)),
+    };
+    if (merged.systemPromptReport && typeof merged.systemPromptReport === "object") {
+      merged.systemPromptReport = {
+        ...merged.systemPromptReport,
+      };
+    }
+    return merged;
+  }
+  return primary ?? secondary ?? null;
+}
+
+export function canonicalPluginSessionKey(agentId, sessionKey) {
+  return `agent:${normalizeAgentId(agentId)}:${sessionKey}`;
+}
+
+// Older plugin builds wrote bare session keys like `phone`, which causes the
+// gateway list view and transcript view to disagree once OpenClaw canonicalizes
+// them to `agent:<id>:phone`. Fold the legacy entry into the canonical key.
+export function resolvePluginSessionEntry({ store, agentId, sessionKey }) {
+  const canonicalKey = canonicalPluginSessionKey(agentId, sessionKey);
+  const canonicalEntry = store[canonicalKey];
+  const legacyEntry = store[sessionKey];
+  const primary =
+    entryUpdatedAt(canonicalEntry) >= entryUpdatedAt(legacyEntry) ? canonicalEntry : legacyEntry;
+  const secondary = primary === canonicalEntry ? legacyEntry : canonicalEntry;
+  const merged = mergeSessionEntries(primary, secondary) ?? {
+    sessionId: crypto.randomUUID(),
+    updatedAt: Date.now(),
+  };
+  if (merged.systemPromptReport && typeof merged.systemPromptReport === "object") {
+    merged.systemPromptReport = {
+      ...merged.systemPromptReport,
+      sessionKey: canonicalKey,
+    };
+  }
+  store[canonicalKey] = merged;
+  if (sessionKey !== canonicalKey) {
+    delete store[sessionKey];
+  }
+  return {
+    key: canonicalKey,
+    entry: merged,
+  };
+}

--- a/test/agent.test.mjs
+++ b/test/agent.test.mjs
@@ -5,6 +5,7 @@ import crypto from "node:crypto";
 
 import { discordLog, openclawReply } from "../lib/agent.mjs";
 import { OPENCLAW_MAX_CONCURRENT, DISCORD_LOG_CHANNEL_ID } from "../lib/config.mjs";
+import { canonicalPluginSessionKey, resolvePluginSessionEntry } from "../lib/plugin-session-key.mjs";
 
 // ─── Helpers for plugin-path tests ───────────────────────────────────────────
 
@@ -131,7 +132,7 @@ describe("openclawReply — plugin path", () => {
 
     const call = /** @type {any[]} */ (deps.runEmbeddedPiAgent.mock.calls)[0].arguments[0];
     assert.strictEqual(call.agentId, "my-agent");
-    assert.strictEqual(call.sessionKey, "my-session");
+    assert.strictEqual(call.sessionKey, "agent:my-agent:my-session");
     assert.strictEqual(call.provider, "openai-codex");
     assert.strictEqual(call.model, "gpt-5.4");
     assert.ok(call.prompt.includes("<= 160 characters"), `unexpected prompt: ${call.prompt}`);
@@ -159,6 +160,7 @@ describe("openclawReply — plugin path", () => {
     const smsKey     = smsCalls[0].arguments[0].sessionKey;
 
     assert.strictEqual(voiceKey, smsKey, "voice and SMS must share the same session key");
+    assert.ok(voiceKey.startsWith("agent:"), `session key must be canonical, got ${voiceKey}`);
     assert.ok(!voiceKey.startsWith("voice:"), `session key must not have mode prefix, got ${voiceKey}`);
     assert.ok(!smsKey.startsWith("sms:"),     `session key must not have mode prefix, got ${smsKey}`);
   });
@@ -210,6 +212,43 @@ describe("openclawReply — plugin path", () => {
     const result = await openclawReply({ userText: "test", run: mockRun });
     assert.strictEqual(result, "CLI reply");
     assert.strictEqual(mockRun.mock.calls.length, 1);
+  });
+});
+
+describe("plugin session keys", () => {
+  it("canonicalizes plugin session keys for the selected agent", () => {
+    assert.strictEqual(canonicalPluginSessionKey("main", "phone"), "agent:main:phone");
+    assert.strictEqual(canonicalPluginSessionKey("Research", "phone"), "agent:research:phone");
+  });
+
+  it("migrates legacy bare plugin session keys into the canonical agent key", () => {
+    const store = {
+      phone: {
+        sessionId: "legacy-session",
+        updatedAt: 200,
+        thinkingLevel: "high",
+        systemPromptReport: {
+          sessionKey: "phone",
+        },
+      },
+      "agent:main:phone": {
+        sessionId: "canonical-session",
+        updatedAt: 100,
+        thinkingLevel: "low",
+      },
+    };
+
+    const { key, entry } = resolvePluginSessionEntry({
+      store,
+      agentId: "main",
+      sessionKey: "phone",
+    });
+
+    assert.strictEqual(key, "agent:main:phone");
+    assert.strictEqual(entry.sessionId, "legacy-session");
+    assert.strictEqual(entry.thinkingLevel, "high");
+    assert.strictEqual(store.phone, undefined);
+    assert.strictEqual(store["agent:main:phone"].systemPromptReport.sessionKey, "agent:main:phone");
   });
 });
 


### PR DESCRIPTION
## Summary
- canonicalize plugin-mode SMS session keys to `agent:<id>:<session>` before calling OpenClaw
- migrate legacy bare plugin keys into the canonical key on first use
- cover the migration and canonical key shape in tests

## Root cause
Plugin mode currently writes the bare `openclawSessionId` into the session store. OpenClaw's gateway/session UI canonicalizes those rows to `agent:<id>:<session>`, so once both key forms exist, `sessions.list` and `chat.history` can disagree about which transcript belongs to the SMS thread.

## Fix
This change keeps the plugin on the canonical agent-prefixed key and folds any legacy bare entry into that canonical key before the next turn runs. That keeps TUI/session history aligned with the live SMS conversation without changing OpenClaw core.

## Verification
- `npm test`
- `npm run lint`
- `npm run typecheck`
